### PR TITLE
Fix #23 and #24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Create Release on Tag Push
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Changes in this Release
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
           echo 'set list("TestCoverage.inc") = ""' >> export
           echo 'do $System.OBJ.Export(.list,"TestCoverage-${{ github.ref }}.xml","/exportversion=2017.2")' >> export
           docker exec --interactive $instance iris session $instance -B < build && docker exec --interactive $instance iris session $instance -B < test && docker exec --interactive $instance iris session $instance -B < export
+          ls -alR
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         id: tag
         uses: actions-ecosystem/action-get-latest-tag@v1
 
-      - name: Build, Test, and Export XML
+      - name: Build and Test
         run: |
           # Run build
           echo "zpm \"load /source $build_flags\":1:1" > build
@@ -63,11 +63,16 @@ jobs:
           echo "do \$System.OBJ.CompilePackage(\"$test_package\",\"ckd\") " > test
           # Run tests
           echo "zpm \"$package test -only $test_flags\":1:1" >> test
+          docker exec --interactive $instance iris session $instance -B < build && docker exec --interactive $instance iris session $instance -B < test && docker exec --interactive $instance iris session $instance -B
+
+      - name: Export XML
+        run: |
           # Pick the targets to export as XML
           echo 'set list("TestCoverage.*.cls") = ""' >> export
           echo 'set list("TestCoverage.inc") = ""' >> export
-          echo 'do $System.OBJ.Export(.list,"TestCoverage-${{ steps.tag.outputs.tag }}.xml","/exportversion=2017.2")' >> export
-          docker exec --interactive $instance iris session $instance -B < build && docker exec --interactive $instance iris session $instance -B < test && docker exec --interactive $instance iris session $instance -B < export
+          echo 'do $System.OBJ.Export(.list,"/source/TestCoverage-${{ steps.tag.outputs.tag }}.xml","/exportversion=2017.2")' >> export
+          docker exec --interactive $instance iris session $instance -B < export
+          ls -lR
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,16 +55,6 @@ jobs:
         id: tag
         uses: actions-ecosystem/action-get-latest-tag@v1
 
-      - name: Build and Test
-        run: |
-          # Run build
-          echo "zpm \"load /source $build_flags\":1:1" > build
-          # Test package is compiled first as a workaround for some dependency issues.
-          echo "do \$System.OBJ.CompilePackage(\"$test_package\",\"ckd\") " > test
-          # Run tests
-          echo "zpm \"$package test -only $test_flags\":1:1" >> test
-          docker exec --interactive $instance iris session $instance -B < build && docker exec --interactive $instance iris session $instance -B < test && docker exec --interactive $instance iris session $instance -B
-
       - name: Export XML
         run: |
           # Pick the targets to export as XML

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,10 @@ jobs:
           # Workaround for permissions issues in TestCoverage (creating directory for source export)
           chmod 777 $GITHUB_WORKSPACE
 
+      - name: Get latest tag
+        id: tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+
       - name: Build, Test, and Export XML
         run: |
           # Run build
@@ -62,9 +66,8 @@ jobs:
           # Pick the targets to export as XML
           echo 'set list("TestCoverage.*.cls") = ""' >> export
           echo 'set list("TestCoverage.inc") = ""' >> export
-          echo 'do $System.OBJ.Export(.list,"TestCoverage-${{ github.ref }}.xml","/exportversion=2017.2")' >> export
+          echo 'do $System.OBJ.Export(.list,"TestCoverage-${{ steps.tag.outputs.tag }}.xml","/exportversion=2017.2")' >> export
           docker exec --interactive $instance iris session $instance -B < build && docker exec --interactive $instance iris session $instance -B < test && docker exec --interactive $instance iris session $instance -B < export
-          ls -alR
 
       - name: Create Release
         id: create_release
@@ -72,9 +75,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: TestCoverage-${{ github.ref }}.xml
+          files: TestCoverage-${{ steps.tag.outputs.tag }}.xml
           tag_name: ${{ github.ref }}
-          name: Release ${{ github.ref }}
+          name: ${{ steps.tag.outputs.tag }}
           body: |
             Automated release created by [action-gh-release](https://github.com/softprops/action-gh-release).
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create Release on Tag Push
+name: Export XML and Release on Tag Push
 
 on:
   push:
@@ -8,18 +8,73 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    env:
+      # ** FOR GENERAL USE, LIKELY NEED TO CHANGE: **
+      package: TestCoverage
+      container_image: intersystemsdc/iris-community:latest
+      
+      # ** FOR GENERAL USE, MAY NEED TO CHANGE: **
+      build_flags: -dev -verbose # Load in -dev mode to get unit test code preloaded
+      test_package: UnitTest
+      
+      # ** FOR GENERAL USE, SHOULD NOT NEED TO CHANGE: **
+      instance: iris
+      # Note: test_reports value is duplicated in test_flags environment variable
+      test_reports: test-reports
+      test_flags: >-
+       -verbose -DUnitTest.ManagerClass=TestCoverage.Manager -DUnitTest.JUnitOutput=/test-reports/junit.xml
+       -DUnitTest.FailuresAreFatal=1 -DUnitTest.Manager=TestCoverage.Manager
+       -DUnitTest.UserParam.CoverageReportClass=TestCoverage.Report.Cobertura.ReportGenerator
+       -DUnitTest.UserParam.CoverageReportFile=/source/coverage.xml
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Run Container
+        run: |
+          # Create test_reports directory to share test results before running container
+          mkdir $test_reports
+          chmod 777 $test_reports
+          # Run InterSystems IRIS instance
+          docker pull $container_image
+          docker run -d -h $instance --name $instance -v $GITHUB_WORKSPACE:/source -v $GITHUB_WORKSPACE/$test_reports:/$test_reports --init $container_image
+          echo halt > wait
+          # Wait for instance to be ready
+          until docker exec --interactive $instance iris session $instance < wait; do sleep 1; done
+
+      - name: Install TestCoverage
+        run: |
+          echo "zpm \"install testcoverage\":1:1" > install-testcoverage
+          docker exec --interactive $instance iris session $instance -B < install-testcoverage
+          # Workaround for permissions issues in TestCoverage (creating directory for source export)
+          chmod 777 $GITHUB_WORKSPACE
+
+      - name: Build, Test, and Export XML
+        run: |
+          # Run build
+          echo "zpm \"load /source $build_flags\":1:1" > build
+          # Test package is compiled first as a workaround for some dependency issues.
+          echo "do \$System.OBJ.CompilePackage(\"$test_package\",\"ckd\") " > test
+          # Run tests
+          echo "zpm \"$package test -only $test_flags\":1:1" >> test
+          # Pick the targets to export as XML
+          echo 'set list("TestCoverage.*.cls") = ""' >> export
+          echo 'set list("TestCoverage.inc") = ""' >> export
+          echo 'do $System.OBJ.Export(.list,"TestCoverage-${{ github.ref }}.xml","/exportversion=2017.2")' >> export
+          docker exec --interactive $instance iris session $instance -B < build && docker exec --interactive $instance iris session $instance -B < test && docker exec --interactive $instance iris session $instance -B < export
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          files: TestCoverage-${{ github.ref }}.xml
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           body: |
-            Changes in this Release
+            Automated release created by [action-gh-release](https://github.com/softprops/action-gh-release).
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
           echo 'set list("TestCoverage.inc") = ""' >> export
           echo 'do $System.OBJ.Export(.list,"/source/TestCoverage-${{ steps.tag.outputs.tag }}.xml","/exportversion=2017.2")' >> export
           docker exec --interactive $instance iris session $instance -B < export
-          ls -lR
 
       - name: Create Release
         id: create_release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - #24: Whenever a new tag is created, a new release will be published using the tag string as its version. The release also comes with an export of the TestCoverage package in XML.
 
-
 ## [3.0.0] - 2023-12-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2024-01-17
+
+### Changed
+- #23: Allow CoverageClasses and CoverageRoutines to be specified as %DynamicArray in addition to $ListBuild() lists.
+
+### Fixed
+- #24: Whenever a new tag is created, a new release will be published using the tag string as its version. The release also comes with an export of the TestCoverage package in XML.
+
+
 ## [3.0.0] - 2023-12-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Generally speaking, set `^UnitTestRoot`, and then call `##class(TestCoverage.Man
 The "userparam" argument can be used to pass information about code coverage data collection. For example:
 
 ```
-Set tCoverageParams("CoverageClasses") = <$ListBuild list of class names for which code coverage data should be collected>
-Set tCoverageParams("CoverageRoutines") = <$ListBuild list of routine names for which code coverage data should be collected>
+Set tCoverageParams("CoverageClasses") = <$ListBuild list or %DynamicArray of class names for which code coverage data should be collected>
+Set tCoverageParams("CoverageRoutines") = <$ListBuild list or %DynamicArray of routine names for which code coverage data should be collected>
 Set tCoverageParams("CoverageDetail") = <0 to track code coverage overall; 1 to track it per test suite (the default); 2 to track it per test class; 3 to track it per test method.>
 Do ##class(TestCoverage.Manager).RunTest(,,.tCoverageParams)
 ```

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -78,7 +78,7 @@ Property Monitor As TestCoverage.Utils.LineByLineMonitor [ InitialExpression = {
 /// </ul>
 /// Granular data is stored in <class>TestCoverage.Data.Coverage</class>; aggregated data is stored per class in <class>TestCoverage.Data.Aggregate.ByCodeUnit</class> and for the whole run in <class>TestCoverage.Data.Aggregate.ByRun</class>.
 /// @API.Method
-ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "", pCoverageLevel As %Integer = 1, ByRef pLogIndex As %Integer, pSourceNamespace As %String = {$NAMESPACE}, pPIDList = {$LISTBUILD($JOB)}, pTiming As %Boolean = 0) As %Status
+ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "", pCoverageLevel As %Integer = 1, ByRef pLogIndex As %Integer, pSourceNamespace As %String = {$Namespace}, pPIDList = {$ListBuild($Job)}, pTiming As %Boolean = 0) As %Status
 {
 	#dim tUnitTestManager As TestCoverage.Manager
 	Set tSuccess = 1

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -67,8 +67,8 @@ Property Monitor As TestCoverage.Utils.LineByLineMonitor [ InitialExpression = {
 /// <ul>
 /// <li><var>pPackage</var> has the top-level package containing all the unit test classes to run. These must already be loaded.</li>
 /// <li><var>pLogFile</var> (optional) may specify a file to log all output to.</li>
-/// <li><var>pCoverageClasses</var> (optional) has a $ListBuild list of class names within which to track code coverage. By default, none are tracked.</li>
-/// <li><var>pCoverageRoutines</var> (optional) has a $ListBuild list of routine names within which to track code coverage. By default, none are tracked.</li>
+/// <li><var>pCoverageClasses</var> (optional) has a $ListBuild list or %DynamicArray of class names within which to track code coverage. By default, none are tracked.</li>
+/// <li><var>pCoverageRoutines</var> (optional) has a $ListBuild list or %DynamicArray of routine names within which to track code coverage. By default, none are tracked.</li>
 /// <li><var>pCoverageLevel</var> (optional) is 0 to track code coverage overall; 1 to track it per test suite (the default); 2 to track it per test class; 3 to track it per test method.
 /// Note that overall tracking is always available; more granular tracking requires more time and disk space.</li>
 /// <li><var>pLogIndex</var> (optional) allows for aggregation of code coverage results across unit test runs. To use this, get it back as output from the first test run, then pass it to the next.</li>
@@ -78,7 +78,7 @@ Property Monitor As TestCoverage.Utils.LineByLineMonitor [ InitialExpression = {
 /// </ul>
 /// Granular data is stored in <class>TestCoverage.Data.Coverage</class>; aggregated data is stored per class in <class>TestCoverage.Data.Aggregate.ByCodeUnit</class> and for the whole run in <class>TestCoverage.Data.Aggregate.ByRun</class>.
 /// @API.Method
-ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "", pCoverageLevel As %Integer = 1, ByRef pLogIndex As %Integer, pSourceNamespace As %String = {$Namespace}, pPIDList = {$ListBuild($Job)}, pTiming As %Boolean = 0) As %Status
+ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "", pCoverageLevel As %Integer = 1, ByRef pLogIndex As %Integer, pSourceNamespace As %String = {$NAMESPACE}, pPIDList = {$LISTBUILD($JOB)}, pTiming As %Boolean = 0) As %Status
 {
 	#dim tUnitTestManager As TestCoverage.Manager
 	Set tSuccess = 1
@@ -94,8 +94,8 @@ ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCov
 		Set tTestSuite = $Replace(pPackage,"/",".")
 		Set tSpec = "/noload/nodelete"
 		Merge tCoverageParams("LogIndex") = pLogIndex // Set only if defined.
-		Set tCoverageParams("CoverageClasses") = pCoverageClasses
-		Set tCoverageParams("CoverageRoutines") = pCoverageRoutines
+		Set tCoverageParams("CoverageClasses") = $SELECT($CLASSNAME(pCoverageClasses) = "%Library.DynamicArray":..ArrayToList(pCoverageClasses), 1:pCoverageClasses)
+		Set tCoverageParams("CoverageRoutines") = $SELECT($CLASSNAME(pCoverageRoutines) = "%Library.DynamicArray":..ArrayToList(pCoverageRoutines), 1:pCoverageRoutines)
 		Set tCoverageParams("CoverageDetail") = pCoverageLevel
 		Set tCoverageParams("SourceNamespace") = pSourceNamespace
 		Set tCoverageParams("ProcessIDs") = pPIDList
@@ -127,6 +127,16 @@ ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCov
 	Use tOldIO
 	Close:tLogFileOpen pLogFile
 	Quit $Select(tSuccess:1,1:$$$ERROR($$$GeneralError,"One or more errors occurred in unit tests."))
+}
+
+ClassMethod ArrayToList(pDynamicArray As %DynamicArray) As %List
+{
+	Set tList = ""
+	Set tIter = pDynamicArray.%GetIterator()
+	While tIter.GetNext(, .value) {
+		Set tList = tList _ $LISTBUILD(value)
+	}
+	Quit tList
 }
 
 Method SetCoverageTargets(pClasses As %List = "", pRoutines As %List = "", pInit As %Boolean = 0) [ Private ]

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="TestCoverage.ZPM"><Module>
   <Name>TestCoverage</Name>
-  <Version>3.0.0</Version>
+  <Version>3.1.0</Version>
   <Description>Run your typical ObjectScript %UnitTest tests and see which lines of your code are executed. Includes Cobertura-style reporting for use in continuous integration tools.</Description>
   <Packaging>module</Packaging>
   <Resource Name="TestCoverage.PKG" Directory="cls" />


### PR DESCRIPTION
- Allow users to pass in CoverageClasses and CoverageRoutines as %DynamicArray, in addition to %List (#23)
- Automatically publish release on tag creation. (#24) 