### PR TITLE
Enhance Release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Export XML and Release on Tag Push
+name: Release
 
 on:
   push:
@@ -10,23 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # ** FOR GENERAL USE, LIKELY NEED TO CHANGE: **
-      package: TestCoverage
       container_image: intersystemsdc/iris-community:latest
-      
-      # ** FOR GENERAL USE, MAY NEED TO CHANGE: **
-      build_flags: -dev -verbose # Load in -dev mode to get unit test code preloaded
-      test_package: UnitTest
-      
-      # ** FOR GENERAL USE, SHOULD NOT NEED TO CHANGE: **
       instance: iris
-      # Note: test_reports value is duplicated in test_flags environment variable
       test_reports: test-reports
-      test_flags: >-
-       -verbose -DUnitTest.ManagerClass=TestCoverage.Manager -DUnitTest.JUnitOutput=/test-reports/junit.xml
-       -DUnitTest.FailuresAreFatal=1 -DUnitTest.Manager=TestCoverage.Manager
-       -DUnitTest.UserParam.CoverageReportClass=TestCoverage.Report.Cobertura.ReportGenerator
-       -DUnitTest.UserParam.CoverageReportFile=/source/coverage.xml
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Export XML and Release on Tag Push
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'  # force semantic versioning
 
 jobs:
-  build:
+  build-and-release:
     runs-on: ubuntu-latest
 
     env:
@@ -51,16 +51,12 @@ jobs:
           # Workaround for permissions issues in TestCoverage (creating directory for source export)
           chmod 777 $GITHUB_WORKSPACE
 
-      - name: Get latest tag
-        id: tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
-
       - name: Export XML
         run: |
           # Pick the targets to export as XML
           echo 'set list("TestCoverage.*.cls") = ""' >> export
           echo 'set list("TestCoverage.inc") = ""' >> export
-          echo 'do $System.OBJ.Export(.list,"/source/TestCoverage-${{ steps.tag.outputs.tag }}.xml","/exportversion=2017.2")' >> export
+          echo 'do $System.OBJ.Export(.list,"/source/TestCoverage-${{ github.ref_name }}.xml","/exportversion=2017.2")' >> export
           docker exec --interactive $instance iris session $instance -B < export
 
       - name: Create Release
@@ -69,9 +65,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: TestCoverage-${{ steps.tag.outputs.tag }}.xml
-          tag_name: ${{ github.ref }}
-          name: ${{ steps.tag.outputs.tag }}
+          files: TestCoverage-${{ github.ref_name }}.xml
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body: |
             Automated release created by [action-gh-release](https://github.com/softprops/action-gh-release).
           draft: false


### PR DESCRIPTION
- Remove unreferenced environment variables
- Only publish a release if the new tag uses semantic versioning
- Use the newly pushed tag (rather than the latest tag) for release. Most of them time they should be the same thing. 