### PR TITLE
Interoperability Process Tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.2.0] - 2024-07-05
 
 ### Added
-- #14: Added a straightforward way to find and track coverage on all interoperability processes in the current namespace ([#14](https://github.com/intersystems/TestCoverage/issues/14))
+- #14: Added a straightforward way to find and track coverage on all interoperability processes in the current namespace
 
 ## [3.1.0] - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2024-07-05
+
+### Added
+- #14: Added a straightforward way to find and track coverage on all interoperability processes in the current namespace ([#14](https://github.com/intersystems/TestCoverage/issues/14))
+
 ## [3.1.0] - 2024-01-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Where:
 * `tCoverageLevel` (optional) is 0 to track code coverage overall; 1 to track it per test suite (the default); 2 to track it per test class; 3 to track it per test method.
 * `tLogIndex` (optional) allows for aggregation of code coverage results across unit test runs. To use this, get it back as output from the first test run, then pass it to the next.
 * `tSourceNamespace` (optional) specifies the namespace in which classes were compiled, defaulting to the current namespace. This may be required to retrieve some metadata.
-* `tPIDList` (optional) has a $ListBuild list of process IDs to monitor. If this is empty, all processes are monitored. If this is $ListBuild("Interop"), all interoperability processes and the current process are monitored. By default, only the current process is monitored.
+* `tPIDList` (optional) has a $ListBuild list of process IDs to monitor. If this is empty, all processes are monitored. If this is $ListBuild("Interop") or "Interoperability", all interoperability processes and the current process are monitored. By default, only the current process is monitored.
 * `tTiming` (optional) is 1 to capture execution time data for monitored classes/routines as well, or 0 (the default) to not capture this data.
 
 ### Viewing Results

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -242,6 +242,18 @@ Method StartCoverageTracking() As %Status [ Private ]
 					}
 				}
 			}
+			ElseIf ($list(tProcessIDs, 1)="Interop")
+			{
+				// Collect the list of PIDs used by Interoperability processes in the current namespace
+				// Run unit tests collecting coverage in that specific list of processes (plus the current process)
+				&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble')
+				If (SQLCODE < 0) {
+					Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
+				}
+				if ('$LISTFIND(tProcessIDs, $Job)) {
+					set $LIST(tProcessIDs, *+1) = $Job
+				}
+			}
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))
 		}
@@ -762,4 +774,3 @@ ClassMethod GetURL(pRunID As %String, Output pHost As %String, Output pPath As %
 }
 
 }
-

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -50,6 +50,8 @@ Property SourceNamespace As %String(MAXLEN = 255) [ Internal, Private ];
 
 Property ProcessIDs As %List [ Internal, Private ];
 
+Property InteroperabilityProcesses As %Boolean [ InitialExpression = 0, Internal, Private ];
+
 Property Run As TestCoverage.Data.Run;
 
 /// Known coverage targets (already snapshotted). <br />
@@ -176,6 +178,24 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
+Method LogAssert(success, action, description, extra, location)
+{
+	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
+	do ##super(success, action, description, extra, location)
+	if (..InteroperabilityProcesses) {
+		// Collect the list of PIDs used by Interoperability processes in the current namespace
+		// Run unit tests collecting coverage in that specific list of processes (plus the current process)
+		&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble')
+		If (SQLCODE < 0) {
+			Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
+		}
+		if ('$LISTFIND(tProcessIDs, $Job)) {
+			set $LIST(tProcessIDs, *+1) = $Job
+		}
+		set ..ProcessIDs = tProcessIDs
+	}
+}
+
 Method StartCoverageTracking() As %Status [ Private ]
 {
 	Set tSC = $$$OK
@@ -242,33 +262,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 					}
 				}
 			}
-			ElseIf ($list(tProcessIDs, 1)="Interop")
-			{
-				// Collect the list of PIDs used by Interoperability processes in the current namespace
-				// Run unit tests collecting coverage in that specific list of processes (plus the current process)
-				&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble')
-				If (SQLCODE < 0) {
-					Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
-				}
-				if ('$LISTFIND(tProcessIDs, $Job)) {
-					set $LIST(tProcessIDs, *+1) = $Job
-				}
-				// Extra check to make sure that monitor is stopped (another chance to get problem processes to unmap from shared memory)
-				// Sometimes the monitor does not stop right away if there are other processes that are being monitored.
-				// The root cause of this is unknown and could use further investigation at some point.
-				Set tMaxAttempts = 5
-				For {
-					Set tUnmappedAll = $zu(84,0,0)
-					Hang 1
-					If (tUnmappedAll) {
-						Quit
-					}
-					If ($Increment(tUnmapCounter) > tMaxAttempts) {
-						Set tMsg = $$$FormatText("Some process(es) still holding on to shared memory for line by line monitor after %1 attempts to release. See console log or cstat -p-1 for details.",tMaxAttempts)
-						$$$ThrowStatus($$$ERROR($$$GeneralError,tMsg))
-					}
-				}
-			}
+			
 			set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))
@@ -564,6 +558,8 @@ ClassMethod OnBeforeAllTests(manager As TestCoverage.Manager, dir As %String, By
 			Set tProcessIDs = ""
 		} ElseIf (tProcessIDs = "") || '$ListValid(tProcessIDs) {
 			Set tProcessIDs = $ListBuild($Job)
+		} ElseIf ($list(tProcessIDs, 1)="Interop") {
+			Set manager.InteroperabilityProcesses = 1
 		}
 		Set tTiming = $Get(userparam("Timing"),0)
 		Set tSubject = $Get(userparam("Subject"))

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -269,6 +269,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 					}
 				}
 			}
+			set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))
 		}

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -178,11 +178,11 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
-Method LogAssert(success, action, description, ByRef extra, location = "")
+Method LogAssert(success, action, description, ByRef extra, location)
 {
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = $lb(success, action, description, extra, $g(location))
-	do ##super(success, action, description, .extra, location)
+	do ##super(success, action, description, .extra, $g(location))
 	if (..InteroperabilityProcesses) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace
 		// Run unit tests collecting coverage in that specific list of processes (plus the current process)

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -178,10 +178,10 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
-Method LogAssert(success, action, description, ByRef extra, location)
+Method LogAssert(success, action, description, ByRef extra, ByRef location)
 {
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
-	do ##super(success, action, description, .extra, location)
+	do ##super(success, action, description, .extra, .location)
 	if (..InteroperabilityProcesses) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace
 		// Run unit tests collecting coverage in that specific list of processes (plus the current process)

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -188,7 +188,7 @@ Method GetInteropProcesses(Output tProcessIDs)
 		Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
 	}
 	if ('$LISTFIND(tProcessIDs, $Job)) {
-		set $LIST(tProcessIDs, *+1) = $Job
+		set tProcessIDs = tProcessIDs _ $ListBuild($Job) 
 	}
 }
 
@@ -198,8 +198,7 @@ Method LogAssert(success, action, description, extra, args...)
 {
 	do ##super(.success, .action, .description, .extra, args...)
 	if (..InteroperabilityProcesses && (description = "StartProduction()")) {
-		
-		do GetInteropProcesses(.tProcessIDs)
+		do ..GetInteropProcesses(.tProcessIDs)
 		set ..ProcessIDs = tProcessIDs
 		$$$ThrowOnError(..EndCoverageTracking())
 		$$$ThrowOnError(..StartCoverageTracking())
@@ -273,7 +272,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 			}
 			ElseIf (..InteroperabilityProcesses)
 			{
-				do GetInteropProcesses(.tProcessIDs)
+				do ..GetInteropProcesses(.tProcessIDs)
 			}
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -178,10 +178,10 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
-Method LogAssert(success, action, description, ByRef extra, location)
+Method LogAssert(success, action, description, ByRef extra, location = "")
 {
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
-	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = $lb(success, action, description, extra, location)
+	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = $lb(success, action, description, extra, $g(location))
 	do ##super(success, action, description, .extra, location)
 	if (..InteroperabilityProcesses) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -178,10 +178,10 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
-Method LogAssert(success, action, description, extra, location)
+Method LogAssert(success, action, description, ByRef extra, location)
 {
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
-	do ##super(success, action, description, extra, location)
+	do ##super(success, action, description, .extra, location)
 	if (..InteroperabilityProcesses) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace
 		// Run unit tests collecting coverage in that specific list of processes (plus the current process)

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -253,8 +253,22 @@ Method StartCoverageTracking() As %Status [ Private ]
 				if ('$LISTFIND(tProcessIDs, $Job)) {
 					set $LIST(tProcessIDs, *+1) = $Job
 				}
+				// Extra check to make sure that monitor is stopped (another chance to get problem processes to unmap from shared memory)
+				// Sometimes the monitor does not stop right away if there are other processes that are being monitored.
+				// The root cause of this is unknown and could use further investigation at some point.
+				Set tMaxAttempts = 5
+				For {
+					Set tUnmappedAll = $zu(84,0,0)
+					Hang 1
+					If (tUnmappedAll) {
+						Quit
+					}
+					If ($Increment(tUnmapCounter) > tMaxAttempts) {
+						Set tMsg = $$$FormatText("Some process(es) still holding on to shared memory for line by line monitor after %1 attempts to release. See console log or cstat -p-1 for details.",tMaxAttempts)
+						$$$ThrowStatus($$$ERROR($$$GeneralError,tMsg))
+					}
+				}
 			}
-			set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))
 		}

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -254,6 +254,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 					set $LIST(tProcessIDs, *+1) = $Job
 				}
 			}
+			set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))
 		}

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -53,11 +53,6 @@ Property ProcessIDs As %List [ Internal, Private ];
 /// 0 means don't bother with interoperability processes, 1 means track interoperability processes
 Property InteroperabilityProcesses As %Integer [ InitialExpression = 0, Internal, Private ];
 
-/// these next two make it easier to start the monitor again with the same parameters
-Property LastRelevantTargets As %List [ Internal, Private ];
-
-Property LastMetrics As %List [ Internal, Private ];
-
 Property Run As TestCoverage.Data.Run;
 
 /// Known coverage targets (already snapshotted). <br />
@@ -81,7 +76,7 @@ Property Monitor As TestCoverage.Utils.LineByLineMonitor [ InitialExpression = {
 /// Note that overall tracking is always available; more granular tracking requires more time and disk space.</li>
 /// <li><var>pLogIndex</var> (optional) allows for aggregation of code coverage results across unit test runs. To use this, get it back as output from the first test run, then pass it to the next.</li>
 /// <li><var>pSourceNamespace</var> (optional) specifies the namespace in which classes were compiled, defaulting to the current namespace. This may be required to retrieve some metadata.</li>
-/// <li><var>pPIDList</var> (optional) has a $ListBuild list of process IDs to monitor. If this is empty, all processes are monitored. By default, this is just the current process.</li>
+/// <li><var>pPIDList</var> (optional) has a $ListBuild list of process IDs to monitor. If this is empty, all processes are monitored. If this is $listbuild("Interop"), the current process and all interoperability processes are monitored. By default, this is just the current process.</li>
 /// <li><var>pTiming</var> (optional) may be set to 1 to also collect timing information per line.</li>
 /// </ul>
 /// Granular data is stored in <class>TestCoverage.Data.Coverage</class>; aggregated data is stored per class in <class>TestCoverage.Data.Aggregate.ByCodeUnit</class> and for the whole run in <class>TestCoverage.Data.Aggregate.ByRun</class>.
@@ -184,13 +179,15 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
+/// Overriden LogAssert method because we want to be able to hook into the StartProduction() call in subclasses of %UnitTest.TestProduction
+/// in order to get the interoperability process list after the production has started 
 Method LogAssert(success, action, description, extra, args...)
 {
 	do ##super(.success, .action, .description, .extra, args...)
 	if (..InteroperabilityProcesses && (description = "StartProduction()")) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace
 		// Run unit tests collecting coverage in that specific list of processes (plus the current process)
-		&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble')
+		&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble' and Namespace = $Namespace)
 		If (SQLCODE < 0) {
 			Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
 		}
@@ -198,10 +195,8 @@ Method LogAssert(success, action, description, extra, args...)
 			set $LIST(tProcessIDs, *+1) = $Job
 		}
 		set ..ProcessIDs = tProcessIDs
-		set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = $lb("inside logassert", tProcessIDs)
 		$$$ThrowOnError(..EndCoverageTracking())
 		$$$ThrowOnError(..StartCoverageTracking())
-		// $$$ThrowOnError(..Monitor.StartWithScope(..LastRelevantTargets, ..LastMetrics, tProcessIDs))
 	}
 }
 
@@ -273,10 +268,9 @@ Method StartCoverageTracking() As %Status [ Private ]
 			}
 			ElseIf ($list(tProcessIDs, 1)="Interop")
 			{
-				// set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "ProcessIDs was still Interop" 
 				// Collect the list of PIDs used by Interoperability processes in the current namespace
 				// Run unit tests collecting coverage in that specific list of processes (plus the current process)
-				&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble')
+				&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble' and Namespace = $Namespace)
 				If (SQLCODE < 0) {
 					Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
 				}
@@ -284,10 +278,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 					set $LIST(tProcessIDs, *+1) = $Job
 				}
 			}
-			set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
-			Set ..LastRelevantTargets = tRelevantTargets
-			Set ..LastMetrics = tMetrics
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))
 		}
 	} Catch e { 

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -198,8 +198,10 @@ Method LogAssert(success, action, description, extra, args...)
 			set $LIST(tProcessIDs, *+1) = $Job
 		}
 		set ..ProcessIDs = tProcessIDs
-		set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
-		$$$ThrowOnError(..Monitor.StartWithScope(..LastRelevantTargets, ..LastMetrics, tProcessIDs))
+		set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = $lb("inside logassert", tProcessIDs)
+		$$$ThrowOnError(..EndCoverageTracking())
+		$$$ThrowOnError(..StartCoverageTracking())
+		// $$$ThrowOnError(..Monitor.StartWithScope(..LastRelevantTargets, ..LastMetrics, tProcessIDs))
 	}
 }
 
@@ -282,7 +284,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 					set $LIST(tProcessIDs, *+1) = $Job
 				}
 			}
-			// set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
+			set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			Set ..LastRelevantTargets = tRelevantTargets
 			Set ..LastMetrics = tMetrics

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -50,7 +50,13 @@ Property SourceNamespace As %String(MAXLEN = 255) [ Internal, Private ];
 
 Property ProcessIDs As %List [ Internal, Private ];
 
-Property InteroperabilityProcesses As %Boolean [ InitialExpression = 0, Internal, Private ];
+/// 0 means don't bother with interoperability processes, 1 means track interoperability processes
+Property InteroperabilityProcesses As %Integer [ InitialExpression = 0, Internal, Private ];
+
+/// these next two make it easier to start the monitor again with the same parameters
+Property LastRelevantTargets As %List [ Internal, Private ];
+
+Property LastMetrics As %List [ Internal, Private ];
 
 Property Run As TestCoverage.Data.Run;
 
@@ -180,9 +186,8 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 
 Method LogAssert(success, action, description, extra, args...)
 {
-	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
 	do ##super(.success, .action, .description, .extra, args...)
-	if (..InteroperabilityProcesses) {
+	if (..InteroperabilityProcesses && (description = "StartProduction()")) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace
 		// Run unit tests collecting coverage in that specific list of processes (plus the current process)
 		&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble')
@@ -194,6 +199,7 @@ Method LogAssert(success, action, description, extra, args...)
 		}
 		set ..ProcessIDs = tProcessIDs
 		set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
+		$$$ThrowOnError(..Monitor.StartWithScope(..LastRelevantTargets, ..LastMetrics, tProcessIDs))
 	}
 }
 
@@ -278,6 +284,8 @@ Method StartCoverageTracking() As %Status [ Private ]
 			}
 			// set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
+			Set ..LastRelevantTargets = tRelevantTargets
+			Set ..LastMetrics = tMetrics
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))
 		}
 	} Catch e { 

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -181,6 +181,7 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 Method LogAssert(success, action, description, ByRef extra, location)
 {
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
+	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = $lb(success, action, description, extra, location)
 	do ##super(success, action, description, .extra, location)
 	if (..InteroperabilityProcesses) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -178,11 +178,10 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
-Method LogAssert(success, action, description, extra, location)
+Method LogAssert(success, action, description, extra, args...)
 {
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
-	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = $lb(success, action, description, extra, $g(location))
-	do ##super(.success, .action, .description, .extra, .location)
+	do ##super(.success, .action, .description, .extra, args...)
 	if (..InteroperabilityProcesses) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace
 		// Run unit tests collecting coverage in that specific list of processes (plus the current process)

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -179,21 +179,27 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
+/// Collect the list of PIDs used by Interoperability processes in the current namespace
+/// In order to run unit tests collecting coverage in that specific list of processes (plus the current process)
+Method GetInteropProcesses(Output tProcessIDs)
+{
+	&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble' and Namespace = $Namespace)
+	If (SQLCODE < 0) {
+		Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
+	}
+	if ('$LISTFIND(tProcessIDs, $Job)) {
+		set $LIST(tProcessIDs, *+1) = $Job
+	}
+}
+
 /// Overriden LogAssert method because we want to be able to hook into the StartProduction() call in subclasses of %UnitTest.TestProduction
 /// in order to get the interoperability process list after the production has started 
 Method LogAssert(success, action, description, extra, args...)
 {
 	do ##super(.success, .action, .description, .extra, args...)
 	if (..InteroperabilityProcesses && (description = "StartProduction()")) {
-		// Collect the list of PIDs used by Interoperability processes in the current namespace
-		// Run unit tests collecting coverage in that specific list of processes (plus the current process)
-		&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble' and Namespace = $Namespace)
-		If (SQLCODE < 0) {
-			Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
-		}
-		if ('$LISTFIND(tProcessIDs, $Job)) {
-			set $LIST(tProcessIDs, *+1) = $Job
-		}
+		
+		do GetInteropProcesses(.tProcessIDs)
 		set ..ProcessIDs = tProcessIDs
 		$$$ThrowOnError(..EndCoverageTracking())
 		$$$ThrowOnError(..StartCoverageTracking())
@@ -268,15 +274,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 			}
 			ElseIf ($list(tProcessIDs, 1)="Interop")
 			{
-				// Collect the list of PIDs used by Interoperability processes in the current namespace
-				// Run unit tests collecting coverage in that specific list of processes (plus the current process)
-				&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble' and Namespace = $Namespace)
-				If (SQLCODE < 0) {
-					Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
-				}
-				if ('$LISTFIND(tProcessIDs, $Job)) {
-					set $LIST(tProcessIDs, *+1) = $Job
-				}
+				do GetInteropProcesses(.tProcessIDs)
 			}
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -193,6 +193,7 @@ Method LogAssert(success, action, description, extra, location)
 			set $LIST(tProcessIDs, *+1) = $Job
 		}
 		set ..ProcessIDs = tProcessIDs
+		set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 	}
 }
 
@@ -264,7 +265,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 			}
 			ElseIf ($list(tProcessIDs, 1)="Interop")
 			{
-				set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "ProcessIDs was still Interop" 
+				// set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "ProcessIDs was still Interop" 
 				// Collect the list of PIDs used by Interoperability processes in the current namespace
 				// Run unit tests collecting coverage in that specific list of processes (plus the current process)
 				&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble')
@@ -275,7 +276,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 					set $LIST(tProcessIDs, *+1) = $Job
 				}
 			}
-			set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
+			// set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))
 		}

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -76,7 +76,7 @@ Property Monitor As TestCoverage.Utils.LineByLineMonitor [ InitialExpression = {
 /// Note that overall tracking is always available; more granular tracking requires more time and disk space.</li>
 /// <li><var>pLogIndex</var> (optional) allows for aggregation of code coverage results across unit test runs. To use this, get it back as output from the first test run, then pass it to the next.</li>
 /// <li><var>pSourceNamespace</var> (optional) specifies the namespace in which classes were compiled, defaulting to the current namespace. This may be required to retrieve some metadata.</li>
-/// <li><var>pPIDList</var> (optional) has a $ListBuild list of process IDs to monitor. If this is empty, all processes are monitored. If this is $listbuild("Interop"), the current process and all interoperability processes are monitored. By default, this is just the current process.</li>
+/// <li><var>pPIDList</var> (optional) has a $ListBuild list of process IDs to monitor. If this is empty, all processes are monitored. If this is $listbuild("Interop") or "Interoperability", the current process and all interoperability processes are monitored. By default, this is just the current process.</li>
 /// <li><var>pTiming</var> (optional) may be set to 1 to also collect timing information per line.</li>
 /// </ul>
 /// Granular data is stored in <class>TestCoverage.Data.Coverage</class>; aggregated data is stored per class in <class>TestCoverage.Data.Aggregate.ByCodeUnit</class> and for the whole run in <class>TestCoverage.Data.Aggregate.ByRun</class>.
@@ -213,7 +213,6 @@ Method StartCoverageTracking() As %Status [ Private ]
 	Try {
 		If (..CoverageTargets '= "") {
 			Set $Namespace = ..SourceNamespace
-			
 			Set tRelevantTargets = ""
 			Set tNewTargets = ""
 			Set tPointer = 0
@@ -272,7 +271,7 @@ Method StartCoverageTracking() As %Status [ Private ]
 					}
 				}
 			}
-			ElseIf ($list(tProcessIDs, 1)="Interop")
+			ElseIf (..InteroperabilityProcesses)
 			{
 				do GetInteropProcesses(.tProcessIDs)
 			}
@@ -568,9 +567,13 @@ ClassMethod OnBeforeAllTests(manager As TestCoverage.Manager, dir As %String, By
 		Set tProcessIDs = $Get(userparam("ProcessIDs"),$ListBuild($Job))
 		If (tProcessIDs = "*") {
 			Set tProcessIDs = ""
-		} ElseIf (tProcessIDs = "") || '$ListValid(tProcessIDs) {
+		} ElseIf ((tProcessIDs = "Interoperability") || (tProcessIDs = "interoperability")) {
+			Set manager.InteroperabilityProcesses = 1
+			Set tProcessIDs = $lb("Interop")
+		}
+		ElseIf (tProcessIDs = "") || '$ListValid(tProcessIDs) {
 			Set tProcessIDs = $ListBuild($Job)
-		} ElseIf ($list(tProcessIDs, 1)="Interop") {
+		} ElseIf (($list(tProcessIDs, 1)="Interop") || ($list(tProcessIDs, 1)="interop") ) {
 			Set manager.InteroperabilityProcesses = 1
 		}
 		Set tTiming = $Get(userparam("Timing"),0)

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -178,10 +178,10 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
-Method LogAssert(success, action, description, ByRef extra, ByRef location)
+Method LogAssert(success, action, description, ByRef extra, location)
 {
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
-	do ##super(success, action, description, .extra, .location)
+	do ##super(success, action, description, .extra, location)
 	if (..InteroperabilityProcesses) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace
 		// Run unit tests collecting coverage in that specific list of processes (plus the current process)

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -262,7 +262,19 @@ Method StartCoverageTracking() As %Status [ Private ]
 					}
 				}
 			}
-			
+			ElseIf ($list(tProcessIDs, 1)="Interop")
+			{
+				set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "ProcessIDs was still Interop" 
+				// Collect the list of PIDs used by Interoperability processes in the current namespace
+				// Run unit tests collecting coverage in that specific list of processes (plus the current process)
+				&sql(select %DLIST(Process) into :tProcessIDs from %SYS.ProcessQuery_SS() where "User" = '_Ensemble')
+				If (SQLCODE < 0) {
+					Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
+				}
+				if ('$LISTFIND(tProcessIDs, $Job)) {
+					set $LIST(tProcessIDs, *+1) = $Job
+				}
+			}
 			set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = tProcessIDs
 			Set tMetrics = $ListBuild("RtnLine") _ $Select(..Timing:$ListBuild("Time","TotalTime"),1:"")
 			$$$ThrowOnError(..Monitor.StartWithScope(tRelevantTargets,tMetrics,tProcessIDs))

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -178,11 +178,11 @@ Method CoverageTargetsSet(%value) As %Status [ Internal, Private ]
 	Quit $$$OK
 }
 
-Method LogAssert(success, action, description, ByRef extra, location)
+Method LogAssert(success, action, description, extra, location)
 {
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = "We're in LogAssert"
 	set ^IRIS.TEMPCG($i(^IRIS.TEMPCG)) = $lb(success, action, description, extra, $g(location))
-	do ##super(success, action, description, .extra, $g(location))
+	do ##super(.success, .action, .description, .extra, .location)
 	if (..InteroperabilityProcesses) {
 		// Collect the list of PIDs used by Interoperability processes in the current namespace
 		// Run unit tests collecting coverage in that specific list of processes (plus the current process)

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="TestCoverage.ZPM"><Module>
   <Name>TestCoverage</Name>
-  <Version>3.1.0</Version>
+  <Version>3.2.0</Version>
   <Description>Run your typical ObjectScript %UnitTest tests and see which lines of your code are executed. Includes Cobertura-style reporting for use in continuous integration tools.</Description>
   <Packaging>module</Packaging>
   <Resource Name="TestCoverage.PKG" Directory="cls" />


### PR DESCRIPTION
Created an extra option for monitoring coverage by the current job as well as all interoperability processes.

Callable by setting tCoverageParams("ProcessIDs") = $ListBuild("Interop") and using RunTest() or by passing in $ListBuild("Interop") as the pPIDList parameter in RunAllTests()

Using "Interoperability" in place of $ListBuild("Interop") works as well. 

Fixes #14 