### PR TITLE
Fix CodeUnit dependencies around UpdateComplexity 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - Unreleased
+
+### Fixed 
+- #46: Fix for bug caused by UpdateComplexity calling GetCurrentByName unnecessarily and causing dependency issues
+
 ## [4.0.0] - 2024-08-01
 
 ### Changed

--- a/cls/TestCoverage/Data/CodeUnit.cls
+++ b/cls/TestCoverage/Data/CodeUnit.cls
@@ -82,9 +82,9 @@ ClassMethod GetCurrentByName(pInternalName As %String, pSourceNamespace As %Stri
 			$$$ThrowOnError(tSC)
 			Set tKnownHash = tMapToResult.%GetData(1)
 			Set tMapToUnit = ..HashOpen(tKnownHash,,.tSC)
-			$$$ThrowOnError(tSC)
-			$$$ThrowOnError(..GetCurrentByName(tMapToUnit.Name_"."_tMapToUnit.Type,pSourceNamespace,.tUpdatedUnit,.pCache))
-			If (tUpdatedUnit.Hash '= tKnownHash) {
+			$$$ThrowOnError(tSC)	
+			do ..GetCurrentHash(tMapToUnit.Name, tMapToUnit.Type, .tUpdatedHash, , )
+			If (tUpdatedHash '= tKnownHash) {
 				//Clear out old data and flag the need for an update.
 				Set tNeedsUpdate = 1
 				&sql(delete from TestCoverage_Data.CodeUnitMap where ToHash = :tKnownHash)
@@ -247,7 +247,6 @@ ClassMethod GetCurrentByName(pInternalName As %String, pSourceNamespace As %Stri
 /// Fill in the LineIsPython property of .cls files 
 Method UpdatePythonLines(pName As %String, ByRef pPyCodeUnit) As %Status
 {
-	
 	Set tSC = $$$OK
 	Set tOriginalNamespace = $Namespace
 	Set tInitTLevel = $TLevel
@@ -543,8 +542,9 @@ Method UpdateComplexity() As %Status
 
 		// python methods
 		If (##class(TestCoverage.Manager).HasPython(..Name)) {
-			do ##class(TestCoverage.Data.CodeUnit).GetCurrentByName(..Name _ ".PY", , .pPyCodeUnit, ) // need the source code for the python
-			set tDocumentText = pPyCodeUnit.Lines.Serialize()
+			do ..GetCurrentHash(..Name, "PY",  ,.tPyCodeArray, ) // need the source code for the python to pass into the method complexity calculator
+			do ##class(TestCoverage.Utils).CodeArrayToList(.tPyCodeArray, .tDocumentText)
+			set tDocumentText = tDocumentText _ $listbuild("")
 			set tMethodComplexities = ..GetPythonComplexities(tDocumentText)
 		}
 

--- a/cls/TestCoverage/Data/CodeUnit.cls
+++ b/cls/TestCoverage/Data/CodeUnit.cls
@@ -44,7 +44,9 @@ Property LineIsPython As array Of %Boolean;
 /// Set to true if this class/routine is generated
 Property Generated As %Boolean [ InitialExpression = 0 ];
 
-/// 
+/// If the CodeUnit has changed since we last updated it, used to see if we need to call UpdateComplexity
+Property OutdatedComplexity As %Boolean [ InitialExpression = 1 ];
+
 /// Methods, branches, etc. within this unit of code.
 Relationship SubUnits As TestCoverage.Data.CodeSubUnit [ Cardinality = children, Inverse = Parent ];
 
@@ -87,6 +89,9 @@ ClassMethod GetCurrentByName(pInternalName As %String, pSourceNamespace As %Stri
 			If (tUpdatedHash '= tKnownHash) {
 				//Clear out old data and flag the need for an update.
 				Set tNeedsUpdate = 1
+				If $IsObject($Get(tMapToUnit)) {
+					set tMapToUnit.OutdatedComplexity = 1 
+				}
 				&sql(delete from TestCoverage_Data.CodeUnitMap where ToHash = :tKnownHash)
 				If (SQLCODE < 0) {
 					Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
@@ -521,9 +526,10 @@ Method UpdateSourceMap(pSourceNamespace As %String, ByRef pCache) As %Status
 			}
 		}
 		
-		// Update cyclomatic complexity for methods in the linked class
+		// Update cyclomatic complexity for methods in the linked class if we don't already have the newest version
 		Set tClass = $Order(tCodeUnits("CLS",""),1,tClassCodeUnit)
-		If $IsObject($Get(tClassCodeUnit)) {
+		If ($IsObject($Get(tClassCodeUnit)) && (tClassCodeUnit.OutdatedComplexity)){
+			set tClassCodeUnit.OutdatedComplexity = 0
 			$$$ThrowOnError(tClassCodeUnit.UpdateComplexity())
 		}
 	} Catch e {
@@ -689,6 +695,9 @@ Storage Default
 </Value>
 <Value name="5">
 <Value>Generated</Value>
+</Value>
+<Value name="6">
+<Value>OutdatedComplexity</Value>
 </Value>
 </Data>
 <Data name="LineIsPython">

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="TestCoverage.ZPM"><Module>
   <Name>TestCoverage</Name>
-  <Version>4.0.0</Version>
+  <Version>4.0.1</Version>
   <Description>Run your typical ObjectScript %UnitTest tests and see which lines of your code are executed. Includes Cobertura-style reporting for use in continuous integration tools.</Description>
   <Packaging>module</Packaging>
   <Resource Name="TestCoverage.PKG" Directory="cls" />


### PR DESCRIPTION
Fixed bug 

ERROR #5002: ObjectScript error: <INVALID OREF>UpdateComplexity+9^TestCoverage.Data.CodeUnit.1  <<==== **FAILED**  

likely caused by circular dependencies involving the GetCurrentByName call in UpdateComplexity, by replacing calls to GetCurrentByName with calls to GetCurrentHash if possible, and also not calling UpdateComplexity unnecessarily.  