### PR TITLE
Embedded Python bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed 
 - #45: Fixed Python line 0 tracking for 2024.2 
 - #46: Fix for bug caused by UpdateComplexity calling GetCurrentByName unnecessarily and causing dependency issues
+- #47: Fixed mapping issue caused by empty lines at top of Python method not showing up in compiled Python
 
 ## [4.0.0] - 2024-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - Unreleased
+
+### Fixed 
+- #46: Fix for bug caused by UpdateComplexity calling GetCurrentByName unnecessarily and causing dependency issues
+
 ## [4.0.0] - 2024-08-01
 
 ### Changed

--- a/cls/TestCoverage/Data/CodeUnit.cls
+++ b/cls/TestCoverage/Data/CodeUnit.cls
@@ -404,17 +404,27 @@ Method UpdateSourceMap(pSourceNamespace As %String, ByRef pCache) As %Status
 				Set tMethodStart = ..MethodMap.GetAt(tMethod)
 				Set tMethodEnd = ..MethodEndMap.GetAt(tMethod)
 				Set tMethodName = tMethod
+
+				// tFullMap(py/int Line Number, absolute) = $lb("CLS", class name, method name, CLS/mac start line (relative to method), CLS/mac end line (relative to method))
 				Set tFullMap(tMethodStart) = $lb("CLS", tClass,tMethodName, -1, -1) ; -1 because the class 
 				; definition doesn't have the +1 offset from the { 
+
+				// there's a strange edge case where if the python method in the .CLS file starts with spaces, that's not captured in the Python compiled code
+				// so we have to find how many empty lines there are at the beginning
+				Set tEmptyLines = 0
+				while ($zstrip( pCLSCodeUnit.Lines.GetAt(tCLSMethodNum + 1 + tEmptyLines + 1), "<>W") = "") {
+					Set tEmptyLines = tEmptyLines + 1 
+				}
+
 				For i = tMethodStart+1:1:tMethodEnd {
 					Set tClassLineNum = i-tMethodStart
-					Set tFullMap(i) = $lb("CLS", tClass,tMethodName, tClassLineNum, tClassLineNum)
+					Set tFullMap(i) = $lb("CLS", tClass,tMethodName, tClassLineNum+tEmptyLines, tClassLineNum+tEmptyLines) 
 
 					// extra check to make sure that the lines we're mapping between are the same as expected
-					Set tClassLineCode = $zstrip(pCLSCodeUnit.Lines.GetAt(tCLSMethodNum + tClassLineNum + 1), "<>W")
+					Set tClassLineCode = $zstrip(pCLSCodeUnit.Lines.GetAt(tCLSMethodNum + 1 + tEmptyLines + tClassLineNum), "<>W")
 					Set tPyLineCode = $zstrip(..Lines.GetAt(i), "<>W")
 					if (tPyLineCode '= tClassLineCode) {
-						Set tSC = $$$ERROR($$$GeneralError,"Compiled .py code doesn't match .CLS python code at line " _ $char(10,13) _ tPyLineCode)
+						$$$ThrowStatus($$$ERROR($$$GeneralError,"Compiled .py code doesn't match .CLS python code at line " _ $char(10,13) _ tPyLineCode))
 					}
 				}
 				Do ..MethodMap.GetNext(.tMethod)
@@ -595,7 +605,7 @@ Method GetMethodOffset(pAbsoluteLine As %Integer, Output pMethod As %String, Out
 {
 }
 
-ClassMethod GetCurrentHash(pName As %String, pType As %String, Output pHash As %String, Output pCodeArray As %String, Output pCache) As %Status [ Private ]
+ClassMethod GetCurrentHash(pName As %String, pType As %String, Output pHash As %String, Output pCodeArray As %String, Output pCache) As %Status
 {
 	Set tSC = $$$OK
 	Try {

--- a/cls/TestCoverage/Data/CodeUnit.cls
+++ b/cls/TestCoverage/Data/CodeUnit.cls
@@ -82,9 +82,9 @@ ClassMethod GetCurrentByName(pInternalName As %String, pSourceNamespace As %Stri
 			$$$ThrowOnError(tSC)
 			Set tKnownHash = tMapToResult.%GetData(1)
 			Set tMapToUnit = ..HashOpen(tKnownHash,,.tSC)
-			$$$ThrowOnError(tSC)
-			$$$ThrowOnError(..GetCurrentByName(tMapToUnit.Name_"."_tMapToUnit.Type,pSourceNamespace,.tUpdatedUnit,.pCache))
-			If (tUpdatedUnit.Hash '= tKnownHash) {
+			$$$ThrowOnError(tSC)	
+			do ..GetCurrentHash(tMapToUnit.Name, tMapToUnit.Type, .tUpdatedHash, , )
+			If (tUpdatedHash '= tKnownHash) {
 				//Clear out old data and flag the need for an update.
 				Set tNeedsUpdate = 1
 				&sql(delete from TestCoverage_Data.CodeUnitMap where ToHash = :tKnownHash)
@@ -247,7 +247,6 @@ ClassMethod GetCurrentByName(pInternalName As %String, pSourceNamespace As %Stri
 /// Fill in the LineIsPython property of .cls files 
 Method UpdatePythonLines(pName As %String, ByRef pPyCodeUnit) As %Status
 {
-	
 	Set tSC = $$$OK
 	Set tOriginalNamespace = $Namespace
 	Set tInitTLevel = $TLevel
@@ -543,8 +542,9 @@ Method UpdateComplexity() As %Status
 
 		// python methods
 		If (##class(TestCoverage.Manager).HasPython(..Name)) {
-			do ##class(TestCoverage.Data.CodeUnit).GetCurrentByName(..Name _ ".PY", , .pPyCodeUnit, ) // need the source code for the python
-			set tDocumentText = pPyCodeUnit.Lines.Serialize()
+			do ..GetCurrentHash(..Name, "PY",  ,.tPyCodeArray, ) // need the source code for the python to pass into the method complexity calculator
+			do ##class(TestCoverage.Utils).CodeArrayToList(.tPyCodeArray, .tDocumentText)
+			set tDocumentText = tDocumentText _ $listbuild("")
 			set tMethodComplexities = ..GetPythonComplexities(tDocumentText)
 		}
 

--- a/cls/TestCoverage/Data/CodeUnit.cls
+++ b/cls/TestCoverage/Data/CodeUnit.cls
@@ -44,7 +44,9 @@ Property LineIsPython As array Of %Boolean;
 /// Set to true if this class/routine is generated
 Property Generated As %Boolean [ InitialExpression = 0 ];
 
-/// 
+/// If the CodeUnit has changed since we last updated it, used to see if we need to call UpdateComplexity
+Property OutdatedComplexity As %Boolean [ InitialExpression = 1 ];
+
 /// Methods, branches, etc. within this unit of code.
 Relationship SubUnits As TestCoverage.Data.CodeSubUnit [ Cardinality = children, Inverse = Parent ];
 
@@ -87,6 +89,9 @@ ClassMethod GetCurrentByName(pInternalName As %String, pSourceNamespace As %Stri
 			If (tUpdatedHash '= tKnownHash) {
 				//Clear out old data and flag the need for an update.
 				Set tNeedsUpdate = 1
+				If $IsObject($Get(tMapToUnit)) {
+					set tMapToUnit.OutdatedComplexity = 1 
+				}
 				&sql(delete from TestCoverage_Data.CodeUnitMap where ToHash = :tKnownHash)
 				If (SQLCODE < 0) {
 					Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
@@ -521,9 +526,10 @@ Method UpdateSourceMap(pSourceNamespace As %String, ByRef pCache) As %Status
 			}
 		}
 		
-		// Update cyclomatic complexity for methods in the linked class
+		// Update cyclomatic complexity for methods in the linked class if we don't already have the newest version
 		Set tClass = $Order(tCodeUnits("CLS",""),1,tClassCodeUnit)
-		If $IsObject($Get(tClassCodeUnit)) {
+		If ($IsObject($Get(tClassCodeUnit)) && (tClassCodeUnit.OutdatedComplexity)){
+			set tClassCodeUnit.OutdatedComplexity = 0
 			$$$ThrowOnError(tClassCodeUnit.UpdateComplexity())
 		}
 	} Catch e {
@@ -689,6 +695,9 @@ Storage Default
 </Value>
 <Value name="5">
 <Value>Generated</Value>
+</Value>
+<Value name="6">
+<Value>OutdatedComplexity</Value>
 </Value>
 </Data>
 <Data name="LineIsPython">

--- a/internal/testing/unit_tests/UnitTest/TestCoverage/Unit/CodeUnit.cls
+++ b/internal/testing/unit_tests/UnitTest/TestCoverage/Unit/CodeUnit.cls
@@ -49,11 +49,13 @@ Method TestCodeUnitCreation()
 		Set tCodeGeneratorLine = tClsCodeUnit.MethodMap.GetAt("SampleCodeGenerator")
 		Set tNormalMethodLine = tClsCodeUnit.MethodMap.GetAt("SampleNormalMethod")
 		Set tPythonMethodLine = tClsCodeUnit.MethodMap.GetAt("SamplePythonMethod")
+		set tPythonWeirdSpacingMethodLine =  tClsCodeUnit.MethodMap.GetAt("PythonWeirdSpacing")
 		
 		Do $$$AssertNotEquals(tConstantReturnValueLine,"")
 		Do $$$AssertNotEquals(tCodeGeneratorLine,"")
 		Do $$$AssertNotEquals(tNormalMethodLine,"")
 		Do $$$AssertNotEquals(tPythonMethodLine,"")
+		Do $$$AssertNotEquals(tPythonWeirdSpacingMethodLine,"")
 
 		// test if LineIsPython is working properly
 		Do $$$AssertEquals(tClsCodeUnit.LineIsPython.GetAt(tPythonMethodLine+2), 1)
@@ -69,6 +71,10 @@ Method TestCodeUnitCreation()
 		Set tTestLines(tNormalMethodLine+3) = $ListBuild("SampleNormalMethod+2",,,tIntCodeUnit.Hash,tIntCodeUnit.MethodMap.GetAt(methodLabel)+2, "INT")
 		Set tTestLines(tPythonMethodLine+2) = $ListBuild("SamplePythonMethod+1",,,tPyCodeUnit.Hash,tPyCodeUnit.MethodMap.GetAt("SamplePythonMethod")+1, "PY")
 		Set tTestLines(tPythonMethodLine+3) = $ListBuild("SamplePythonMethod+2",,,tPyCodeUnit.Hash,tPyCodeUnit.MethodMap.GetAt("SamplePythonMethod")+2, "PY")
+		Set tTestLines(tPythonWeirdSpacingMethodLine+4) = $ListBuild("PythonWeirdSpacing+1",,,tPyCodeUnit.Hash,tPyCodeUnit.MethodMap.GetAt("PythonWeirdSpacing")+1, "PY")
+		Set tTestLines(tPythonWeirdSpacingMethodLine+5) = $ListBuild("PythonWeirdSpacing+2",,,tPyCodeUnit.Hash,tPyCodeUnit.MethodMap.GetAt("PythonWeirdSpacing")+2, "PY")
+		Set tTestLines(tPythonWeirdSpacingMethodLine+6) = $ListBuild("PythonWeirdSpacing+3",,,tPyCodeUnit.Hash,tPyCodeUnit.MethodMap.GetAt("PythonWeirdSpacing")+3, "PY")
+		
 		Set tLine = ""
 		For {
 			Set tLine = $Order(tTestLines(tLine),1,tInfo)
@@ -147,6 +153,15 @@ ClassMethod SamplePythonMethod() [ Language = python ]
 {
 	import iris
 	return 50
+}
+
+ClassMethod PythonWeirdSpacing() [ Language = python ]
+{
+
+
+	x = [0] * 10
+	x.append([50])
+	return [element * 2 for element in x]
 }
 
 }

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="TestCoverage.ZPM"><Module>
   <Name>TestCoverage</Name>
-  <Version>4.0.0</Version>
+  <Version>4.0.1</Version>
   <Description>Run your typical ObjectScript %UnitTest tests and see which lines of your code are executed. Includes Cobertura-style reporting for use in continuous integration tools.</Description>
   <Packaging>module</Packaging>
   <Resource Name="TestCoverage.PKG" Directory="cls" />


### PR DESCRIPTION
Bug fixes related to Embedded Python: 

- Fixed bug ERROR #5002: ObjectScript error: UpdateComplexity+9^TestCoverage.Data.CodeUnit.1 <<==== FAILED
likely caused by circular dependencies involving the GetCurrentByName call in UpdateComplexity, by replacing calls to GetCurrentByName with calls to GetCurrentHash if possible, and also not calling UpdateComplexity unnecessarily.

- Fixed mapping issue caused by empty lines at top of Python method not showing up in compiled Python. The error handling for inconsistent Python and CLS code is now working, and I also wrote a unit test for the empty line issue. 