### PR TITLE
Fix pause monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.1] - 2024-08-09
+## [4.0.1] - Unreleased
 
 ### Fixed 
 - #45: Fixed Python line 0 tracking for 2024.2 
 - #46: Fix for bug caused by UpdateComplexity calling GetCurrentByName unnecessarily and causing dependency issues
 - #47: Fixed mapping issue caused by empty lines at top of Python method not showing up in compiled Python
+- #48: When the Line-By-Line Monitor resumes after pausing, resume the Python tracer too 
 
 ## [4.0.0] - 2024-08-01
 

--- a/cls/TestCoverage/Utils.cls
+++ b/cls/TestCoverage/Utils.cls
@@ -1,4 +1,4 @@
-Include %occInclude
+Include (%occInclude, TestCoverage)
 
 IncludeGenerator TestCoverage
 
@@ -18,6 +18,7 @@ ClassMethod Clear() As %Status
 		Set tClasses("TestCoverage.Data.CodeUnit") = ""
 		Set tClasses("TestCoverage.Data.Coverage") = ""
 		Set tClasses("TestCoverage.Data.Run") = ""
+		kill $$$PyMonitorResults
 		
 		Set tClass = ""
 		For {

--- a/cls/TestCoverage/Utils/LineByLineMonitor.cls
+++ b/cls/TestCoverage/Utils/LineByLineMonitor.cls
@@ -123,6 +123,7 @@ Method StartWithScope(pRoutineList As %List, pPyClasses As %List, pMetricList As
 			$$$ThrowOnError(tSC)
 			If ..Paused {
 				$$$ThrowOnError(..Resume())
+				Do ..PyStartWithScope(pPyClasses)
 			}
 		}
 	} Catch e {


### PR DESCRIPTION
At the end of a test suite or the equivalent for the coverage level (i.e. when EndCoverageTracking is called but the unit tests aren't completely done), we call Pause() on the Line-By-Line Monitor, but when that resumes, I previously didn't resume the Python coverage tracker; now we do. 