### PR TITLE
PreloadModules 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #46: Fix for bug caused by UpdateComplexity calling GetCurrentByName unnecessarily and causing dependency issues
 - #47: Fixed mapping issue caused by empty lines at top of Python method not showing up in compiled Python
 - #48: When the Line-By-Line Monitor resumes after pausing, resume the Python tracer too 
+- #49: Added user parameter for preloading python modules (fixes problem of pandas breaking sys.settrace on first import)
 
 ## [4.0.0] - 2024-08-01
 

--- a/README.md
+++ b/README.md
@@ -57,12 +57,16 @@ zw ##class(TestCoverage.Utils).GrantSQLReadPermissions("_PUBLIC")
 ### Running Tests with Coverage
 Generally speaking, set `^UnitTestRoot`, and then call `##class(TestCoverage.Manager).RunTest()` the same you would call `##class(%UnitTest.Manager).RunTest()`. For more information on InterSystems' %UnitTest framework, see the [tutorial](https://docs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=TUNT) and/or the [class reference for %UnitTest.Manager](https://docs.intersystems.com/irislatest/csp/documatic/%25CSP.Documatic.cls?PAGE=CLASS&LIBRARY=%25SYS&CLASSNAME=%25UnitTest.Manager).
 
-The "userparam" argument can be used to pass information about code coverage data collection. For example:
+The "userparam" argument can be used to pass optional information about code coverage data collection. For example:
 
 ```
 Set tCoverageParams("CoverageClasses") = <$ListBuild list or %DynamicArray of class names for which code coverage data should be collected>
 Set tCoverageParams("CoverageRoutines") = <$ListBuild list or %DynamicArray of routine names for which code coverage data should be collected>
 Set tCoverageParams("CoverageDetail") = <0 to track code coverage overall; 1 to track it per test suite (the default); 2 to track it per test class; 3 to track it per test method.>
+Set tCoverageParams("ProcessIDs") = <$ListBuild list of process IDs to monitor, or "Interoperability"> 
+Set tCoverageParams("Timing") = <1 to capture timing data, 0 to not> 
+Set tCoverageParams("PyModules") = <$ListBuild list of Python module names to preload> 
+Set tCoverageParams("ListenerManager") = <instance of TestCoverage.Listeners.ListenerManager>) 
 Do ##class(TestCoverage.Manager).RunTest(,,.tCoverageParams)
 ```
 
@@ -96,6 +100,9 @@ Where:
 * `tSourceNamespace` (optional) specifies the namespace in which classes were compiled, defaulting to the current namespace. This may be required to retrieve some metadata.
 * `tPIDList` (optional) has a $ListBuild list of process IDs to monitor. If this is empty, all processes are monitored. If this is $ListBuild("Interop") or "Interoperability", all interoperability processes and the current process are monitored. By default, only the current process is monitored.
 * `tTiming` (optional) is 1 to capture execution time data for monitored classes/routines as well, or 0 (the default) to not capture this data.
+* `tListenerManager` (optional)  is an instance of TestCoverage.Listeners.ListenerManager that allows downstream applications to listen to the completion of unit test suites/cases/methods. It should use the AddListener method to populate with listeners that extend TestCoverage.Listeners.ListenerInterface. See [isc.perf.ui](https://github.com/intersystems/isc-perf-ui) for an example usage
+* `tPyModules` a $ListBuild list of Python module names the covered code uses that should be imported before the unit tests are run. This is for modules like pandas and scikit-learn, whose import sometimes breaks sys.settrace 
+
 
 ### Running Tests with Coverage via IPM
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Where:
 * `tPIDList` (optional) has a $ListBuild list of process IDs to monitor. If this is empty, all processes are monitored. If this is $ListBuild("Interop") or "Interoperability", all interoperability processes and the current process are monitored. By default, only the current process is monitored.
 * `tTiming` (optional) is 1 to capture execution time data for monitored classes/routines as well, or 0 (the default) to not capture this data.
 * `tListenerManager` (optional)  is an instance of TestCoverage.Listeners.ListenerManager that allows downstream applications to listen to the completion of unit test suites/cases/methods. It should use the AddListener method to populate with listeners that extend TestCoverage.Listeners.ListenerInterface. See [isc.perf.ui](https://github.com/intersystems/isc-perf-ui) for an example usage
-* `tPyModules` a $ListBuild list of Python module names the covered code uses that should be imported before the unit tests are run. This is for modules like pandas and scikit-learn, whose import sometimes breaks sys.settrace 
+* `tPyModules` a $ListBuild list of Python module names the covered code uses that should be imported before the unit tests are run. This is for modules like `pandas` and `sklearn`, whose import sometimes breaks sys.settrace 
 
 
 ### Running Tests with Coverage via IPM

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -95,7 +95,7 @@ Property ListenerManager As TestCoverage.Listeners.ListenerManager;
 /// </ul>
 /// Granular data is stored in <class>TestCoverage.Data.Coverage</class>; aggregated data is stored per class in <class>TestCoverage.Data.Aggregate.ByCodeUnit</class> and for the whole run in <class>TestCoverage.Data.Aggregate.ByRun</class>.
 /// @API.Method
-ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "", pCoverageLevel As %Integer = 1, ByRef pLogIndex As %Integer, pSourceNamespace As %String = {$Namespace}, pPIDList = {$ListBuild($Job)}, pTiming As %Boolean = 0) As %Status
+ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCoverageClasses As %List = "", pCoverageRoutines As %List = "", pCoverageLevel As %Integer = 1, ByRef pLogIndex As %Integer, pSourceNamespace As %String = {$Namespace}, pPIDList = {$ListBuild($Job)}, pTiming As %Boolean = 0, pListenerManager As TestCoverage.Listeners.ListenerManager = "", pPyModules As %List = "") As %Status
 {
 	#dim tUnitTestManager As TestCoverage.Manager
 	Set tSuccess = 1
@@ -117,6 +117,8 @@ ClassMethod RunAllTests(pPackage As %String = "", pLogFile As %String = "", pCov
 		Set tCoverageParams("SourceNamespace") = pSourceNamespace
 		Set tCoverageParams("ProcessIDs") = pPIDList
 		Set tCoverageParams("Timing") = pTiming
+		Set tCoverageParams("ListenerManager") = pListenerManager
+		Set tCoverageParams("PyModules") = pPyModules
 		Do ..RunTest(tTestSuite,tSpec,.tCoverageParams)
 		
 		Set tFailed = 0
@@ -629,6 +631,7 @@ ClassMethod OnBeforeAllTests(manager As TestCoverage.Manager, dir As %String, By
 		Set tSourceNamespace = $Get(userparam("SourceNamespace"),$Namespace)
 		Set tListenerManager = $Get(userparam("ListenerManager"))
 		Set tProcessIDs = $Get(userparam("ProcessIDs"),$ListBuild($Job))
+		Set tPyModules = $Get(userparam("PyModules")) 
 		If (tProcessIDs = "*") {
 			Set tProcessIDs = ""
 		} ElseIf ((tProcessIDs = "Interoperability") || (tProcessIDs = "interoperability")) {
@@ -687,6 +690,11 @@ ClassMethod OnBeforeAllTests(manager As TestCoverage.Manager, dir As %String, By
 			set tObj = {"message": "Starting tests"}
 			Do manager.ListenerManager.BroadCastToAll(tObj)
 		}
+		set tPointer = 0
+		while $ListNext(tPyModules, tPointer, tCurModule) {
+			do ##class(%SYS.Python).Import(tCurModule)
+		}
+		
 		If (manager.CoverageDetail = 0) {
 			Set tSC = manager.StartCoverageTracking()
 			$$$ThrowOnError(tSC)


### PR DESCRIPTION
Add in a user parameter to allow the user to pass in python modules to be preloaded before the unit test execution; needed because on the first import, some modules like pandas and scikit-learn interfere with sys.settrace  