### PR TITLE
Unnamed classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 
 - #52: Method mapping code now doesn't use AST's endline_no property to support older python versions 
+- #53: Ignore traced commands from code without a class name
 
 ## [4.0.2] - 2024-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.3] - 2024-08-16
+## [4.0.3] - Unreleased
 
 ### Changed 
-- #53: Method mapping code now doesn't use AST's endline_no property to support older python versions 
+- #52: Method mapping code now doesn't use AST's endline_no property to support older python versions 
 
 ## [4.0.2] - 2024-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.3] - 2024-08-16
+
+### Changed 
+- #53: Method mapping code now doesn't use AST's endline_no property to support older python versions 
+
 ## [4.0.2] - 2024-08-16
 
 ### Fixed

--- a/cls/TestCoverage/Utils.cls
+++ b/cls/TestCoverage/Utils.cls
@@ -451,9 +451,8 @@ ClassMethod GetPythonMethodMapping(pDocumentText) [ Language = python ]
 	import iris
 	import ast 
 	source_lines = iris.cls('%SYS.Python').ToList(pDocumentText)
-	source_lines = [line + "\n" for line in source_lines]  # contains a list of each line of the source code
 
-	source = ''.join(source_lines)
+	source = '\n'.join(source_lines)
 	tree = ast.parse(source)
 	line_function_map = [None] * (len(source_lines)+2)
 	method_map = {} # dictionary from the method name to its start and ending line number
@@ -473,7 +472,9 @@ ClassMethod GetPythonMethodMapping(pDocumentText) [ Language = python ]
 		def visit_FunctionDef(self, node):
 			if self.outermost_function is None:
 				self.outermost_function = node.name
-				method_map[node.name] = (node.lineno-1, node.end_lineno-1) 
+				start_line = node.lineno
+				end_line = self.get_end_line(node)
+				method_map[node.name] = (start_line, end_line)
 
 			self.current_function = node.name
 			for lineno in range(node.lineno, node.end_lineno + 1):
@@ -483,14 +484,18 @@ ClassMethod GetPythonMethodMapping(pDocumentText) [ Language = python ]
 			self.current_function = None
 			if self.outermost_function == node.name:
 				self.outermost_function = None
-
-	# preprocessing the ending line number for each function 
-	tree_with_line_numbers = ast.increment_lineno(tree, n=1)
-	for node in ast.walk(tree_with_line_numbers):
-		if isinstance(node, ast.FunctionDef):
-			node.end_lineno = node.body[-1].end_lineno
+		@staticmethod
+		def get_end_line(node):
+			return max(child.lineno for child in ast.walk(node) if hasattr(child, 'lineno'))
+	#; # preprocessing the ending line number for each function 
+	#; tree_with_line_numbers = ast.increment_lineno(tree, n=1)
+	#; for node in ast.walk(tree_with_line_numbers):
+	#; 	if isinstance(node, ast.FunctionDef):
+	#; 		node.end_lineno = node.body[-1].end_lineno
 
 	FunctionMapper().visit(tree)
+	print(source_lines)
+	print(method_map)
 	return (line_function_map, method_map)
 }
 

--- a/cls/TestCoverage/Utils.cls
+++ b/cls/TestCoverage/Utils.cls
@@ -489,8 +489,6 @@ ClassMethod GetPythonMethodMapping(pDocumentText) [ Language = python ]
 			return max(child.lineno for child in ast.walk(node) if hasattr(child, 'lineno'))
 
 	FunctionMapper().visit(tree)
-	print(source_lines)
-	print(method_map)
 	return (line_function_map, method_map)
 }
 

--- a/cls/TestCoverage/Utils.cls
+++ b/cls/TestCoverage/Utils.cls
@@ -487,11 +487,6 @@ ClassMethod GetPythonMethodMapping(pDocumentText) [ Language = python ]
 		@staticmethod
 		def get_end_line(node):
 			return max(child.lineno for child in ast.walk(node) if hasattr(child, 'lineno'))
-	#; # preprocessing the ending line number for each function 
-	#; tree_with_line_numbers = ast.increment_lineno(tree, n=1)
-	#; for node in ast.walk(tree_with_line_numbers):
-	#; 	if isinstance(node, ast.FunctionDef):
-	#; 		node.end_lineno = node.body[-1].end_lineno
 
 	FunctionMapper().visit(tree)
 	print(source_lines)

--- a/cls/TestCoverage/Utils.cls
+++ b/cls/TestCoverage/Utils.cls
@@ -477,7 +477,7 @@ ClassMethod GetPythonMethodMapping(pDocumentText) [ Language = python ]
 				method_map[node.name] = (start_line, end_line)
 
 			self.current_function = node.name
-			for lineno in range(node.lineno, node.end_lineno + 1):
+			for lineno in range(node.lineno, self.get_end_line(node) + 1):
 				line_function_map[lineno-1] = self.outermost_function
 
 			self.generic_visit(node)

--- a/cls/TestCoverage/Utils/LineByLineMonitor.cls
+++ b/cls/TestCoverage/Utils/LineByLineMonitor.cls
@@ -76,10 +76,10 @@ ClassMethod PyStartWithScope(pCoverageClasses As %List) [ Language = python ]
 		# extracts frame code 
 		code = frame.f_code 
 		# extracts calling function name and the class that the function is in 
-		class_name = frame.f_globals['__name__']
+		class_name = frame.f_globals.get('__name__', None)  # Use get to avoid KeyError
 		# extracts the line number 
 		line_no = frame.f_lineno 
-		if class_name in tCoverageClasses and line_no > 1: # if this is in a covered class 
+		if class_name and class_name in tCoverageClasses and line_no > 1: # if this is in a covered class 
 			tGlob = iris.gref('^IRIS.Temp.TestCoveragePY') # python doesn't have macros -- this is $$$PyMonitorResults
 			# $$$PyMonitorResults(classname, linenumber) = the number of times that linenumber in that class was covered 
 

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="TestCoverage.ZPM"><Module>
   <Name>TestCoverage</Name>
-  <Version>4.0.2</Version>
+  <Version>4.0.3</Version>
   <Description>Run your typical ObjectScript %UnitTest tests and see which lines of your code are executed. Includes Cobertura-style reporting for use in continuous integration tools.</Description>
   <Packaging>module</Packaging>
   <Resource Name="TestCoverage.PKG" Directory="cls" />


### PR DESCRIPTION
Ignore Python tracer hits from lines of code that don't have an attached class name (__name__ isn't in the globals) 