### PR TITLE
feat: improve SQL performance of MapRunCoverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.5] - 2024-11-04
+
+### Fixed 
+- #57: Improve SQL performance when mapping run coverage
+
 ## [4.0.4] - 2024-10-15
 
 ### Fixed 

--- a/cls/TestCoverage/Data/Run.cls
+++ b/cls/TestCoverage/Data/Run.cls
@@ -128,11 +128,11 @@ ClassMethod MapRunCoverage(pRunIndex As %Integer) As %Status
 			Set tSQLStatement = "INSERT OR UPDATE %NOLOCK %NOCHECK INTO TestCoverage_Data.Coverage_"_tMetric_" "_
 				"(Coverage,element_key,"_tMetric_") "_
 				"SELECT target.ID,map.ToLine,NVL(oldMetric."_tMetric_",0) + SUM(metric."_tMetric_") "_
-				"FROM TestCoverage_Data.Coverage source "_
-				"JOIN TestCoverage_Data.CodeUnitMap map "_
-				"	ON source.Hash = map.FromHash "_
+				"FROM %INORDER TestCoverage_Data.Coverage source "_
 				"JOIN TestCoverage_Data.Coverage_"_tMetric_" metric "_
 				"	ON metric.Coverage = source.ID "_
+				"JOIN TestCoverage_Data.CodeUnitMap map "_
+				"	ON source.Hash = map.FromHash "_
 				"	AND metric.element_key = map.FromLine "_
 				"JOIN TestCoverage_Data.Coverage target "_
 				"	ON target.Run = source.Run "_

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="TestCoverage.ZPM"><Module>
   <Name>TestCoverage</Name>
-  <Version>4.0.4</Version>
+  <Version>4.0.5</Version>
   <Description>Run your typical ObjectScript %UnitTest tests and see which lines of your code are executed. Includes Cobertura-style reporting for use in continuous integration tools.</Description>
   <Packaging>module</Packaging>
   <Resource Name="TestCoverage.PKG" Directory="cls" />


### PR DESCRIPTION
Fix #56 by adding the %INORDER keyword and tweaking the order of SQL joins