### PR TITLE
fix: call superclass in TestCoverage.Manager so updates to %UnitTest.Manager will be propagated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.6]
+
+### Fixed
+- #63: TestCoverage.Manager On/After methods now call superclass so improvements to %UnitTest.Manager like AutoUserNames will work properly
+
 ## [4.0.5] - 2024-11-04
 
 ### Fixed 

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -631,7 +631,7 @@ ClassMethod OnBeforeAllTests(manager As TestCoverage.Manager, dir As %String, By
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.manager, .dir, .qstruct, .userparam)
+		Set tSC = ##super(.manager, .dir, .qstruct, .userparam)
 		Set tCoverageClasses = $Get(userparam("CoverageClasses"))
 		Set tCoverageRoutines = $Get(userparam("CoverageRoutines"))
 		Set tCoverageDetail = $Get(userparam("CoverageDetail"))
@@ -719,9 +719,12 @@ ClassMethod OnAfterAllTests(manager As TestCoverage.Manager, dir As %String, ByR
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.manager, .dir, .qstruct, .userparam)
+		Set tSC = ##super(.manager, .dir, .qstruct, .userparam)
 		If (manager.CoverageDetail = 0) {
-			Set tSC = manager.EndCoverageTracking()
+			Set sc = manager.EndCoverageTracking()
+			If $$$ISERR(sc) {
+				Set tSC = $$$ADDSC(tSC,sc)
+			}
 			if (manager.ListenerManager) {
 				set tObj = {"message": "All tests complete"}
 				Do manager.ListenerManager.BroadCastToAll(tObj)
@@ -745,7 +748,7 @@ Method OnBeforeAutoLoad(dir As %String, suite As %String, testspec As %String, B
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.dir, .suite, .testspec, .qstruct)
+		Set tSC = ##super(.dir, .suite, .testspec, .qstruct)
 		// TODO: Flag to capture code coverage of compiling autoload classes? (e.g., to cover generators?)
 	} Catch e {
 		Set tSC = e.AsStatus()
@@ -760,7 +763,7 @@ Method OnBeforeTestSuite(dir As %String, suite As %String, testspec As %String, 
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.dir, .suite, .testspec, .qstruct)
+		Set tSC = ##super(.dir, .suite, .testspec, .qstruct)
 		If ..DynamicTargets && (dir '= "") {
 			// Determine coverage targets based on directory contents (looking for coverage.list in that directory or the nearest ancestor containing it).
 			Set tSC = ..UpdateCoverageTargetsForTestDirectory(dir)
@@ -775,7 +778,10 @@ Method OnBeforeTestSuite(dir As %String, suite As %String, testspec As %String, 
 			Do ..ListenerManager.BroadCastToAll(tObj)
 		}
 		If (..CoverageDetail = 1) {
-			Set tSC = ..StartCoverageTracking()
+			Set sc = ..StartCoverageTracking()
+			If $$$ISERR(sc) {
+				Set tSC = $$$ADDSC(tSC,sc)
+			}
 		}
 		
 	} Catch e {
@@ -790,10 +796,13 @@ Method OnAfterTestSuite(dir As %String, suite As %String, testspec As %String, B
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.dir, .suite, .testspec, .qstruct)
+		Set tSC = ##super(.dir, .suite, .testspec, .qstruct)
 		
 		If (..CoverageDetail = 1) {
-			Set tSC = ..EndCoverageTracking($Case(suite,"":"(root)",:suite))
+			Set sc = ..EndCoverageTracking($Case(suite,"":"(root)",:suite))
+			If $$$ISERR(sc) {
+				Set tSC = $$$ADDSC(tSC,sc)
+			}
 		}
 		if (..ListenerManager) {
 			set tObj = {"message": "Finished test suite: "}
@@ -812,7 +821,7 @@ Method OnBeforeTestCase(suite As %String, class As %String) As %Status
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.suite, .class, .testcase)
+		Set tSC = ##super(.suite, .class, .testcase)
 		Set ..CurrentTestClass = class
 		Set ..CurrentTestMethod = ""
 		if (..ListenerManager) {
@@ -822,7 +831,10 @@ Method OnBeforeTestCase(suite As %String, class As %String) As %Status
 			Do ..ListenerManager.BroadCastToAll(tObj)
 		}
 		If (..CoverageDetail = 2) {
-			Set tSC = ..StartCoverageTracking()
+			Set sc = ..StartCoverageTracking()
+			If $$$ISERR(sc) {
+				Set tSC = $$$ADDSC(tSC,sc)
+			}
 		}
 	} Catch e {
 		Set tSC = e.AsStatus()
@@ -836,9 +848,12 @@ Method OnAfterTestCase(suite As %String, class As %String) As %Status
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.suite, .class, .testcase)
+		Set tSC = ##super(.suite, .class, .testcase)
 		If (..CoverageDetail = 2) {
-			Set tSC = ..EndCoverageTracking(suite, class)
+			Set sc = ..EndCoverageTracking(suite, class)
+			If $$$ISERR(sc) {
+				Set tSC = $$$ADDSC(tSC,sc)
+			}
 		}
 		if (..ListenerManager) {
 			set tObj = {"message": "Finished test case: "}
@@ -858,7 +873,7 @@ Method OnBeforeOneTest(suite As %String, class As %String, method As %String) As
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.suite, .class, .method)
+		Set tSC = ##super(.suite, .class, .method)
 		Set ..CurrentTestMethod = method
 		if (..ListenerManager) {
 			set tObj = {"message": "Starting test method: "}
@@ -868,7 +883,10 @@ Method OnBeforeOneTest(suite As %String, class As %String, method As %String) As
 			Do ..ListenerManager.BroadCastToAll(tObj)
 		}
 		If (..CoverageDetail = 3) {
-			Set tSC = ..StartCoverageTracking()
+			Set sc = ..StartCoverageTracking()
+			If $$$ISERR(sc) {
+				Set tSC = $$$ADDSC(tSC,sc)
+			}
 		}
 	} Catch e {
 		Set tSC = e.AsStatus()
@@ -882,9 +900,12 @@ Method OnAfterOneTest(suite As %String, class As %String, method As %String) As 
 {
 	Set tSC = $$$OK
 	Try {
-		Do ##super(.suite, .class, .method)
+		Set tSC = ##super(.suite, .class, .method)
 		If (..CoverageDetail = 3) {
-			Set tSC = ..EndCoverageTracking(suite, class, method)
+			Set sc = ..EndCoverageTracking(suite, class, method)
+			If $$$ISERR(sc) {
+				Set tSC = $$$ADDSC(tSC,sc)
+			}
 		}
 		if (..ListenerManager) {
 			set tObj = {"message": "Finished test method: "}

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -592,6 +592,7 @@ Method OnAfterSaveResult(ByRef userparam)
 {
 	Try {
 		Quit:'$IsObject(..Run)
+		Do ##super(.userparam)
 		
 		// Associate to unit test results.
 		Do ..Run.TestResultsSetObjectId(..LogIndex)
@@ -630,6 +631,7 @@ ClassMethod OnBeforeAllTests(manager As TestCoverage.Manager, dir As %String, By
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.manager, .dir, .qstruct, .userparam)
 		Set tCoverageClasses = $Get(userparam("CoverageClasses"))
 		Set tCoverageRoutines = $Get(userparam("CoverageRoutines"))
 		Set tCoverageDetail = $Get(userparam("CoverageDetail"))
@@ -717,6 +719,7 @@ ClassMethod OnAfterAllTests(manager As TestCoverage.Manager, dir As %String, ByR
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.manager, .dir, .qstruct, .userparam)
 		If (manager.CoverageDetail = 0) {
 			Set tSC = manager.EndCoverageTracking()
 			if (manager.ListenerManager) {
@@ -742,6 +745,7 @@ Method OnBeforeAutoLoad(dir As %String, suite As %String, testspec As %String, B
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.dir, .suite, .testspec, .qstruct)
 		// TODO: Flag to capture code coverage of compiling autoload classes? (e.g., to cover generators?)
 	} Catch e {
 		Set tSC = e.AsStatus()
@@ -756,6 +760,7 @@ Method OnBeforeTestSuite(dir As %String, suite As %String, testspec As %String, 
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.dir, .suite, .testspec, .qstruct)
 		If ..DynamicTargets && (dir '= "") {
 			// Determine coverage targets based on directory contents (looking for coverage.list in that directory or the nearest ancestor containing it).
 			Set tSC = ..UpdateCoverageTargetsForTestDirectory(dir)
@@ -785,6 +790,7 @@ Method OnAfterTestSuite(dir As %String, suite As %String, testspec As %String, B
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.dir, .suite, .testspec, .qstruct)
 		
 		If (..CoverageDetail = 1) {
 			Set tSC = ..EndCoverageTracking($Case(suite,"":"(root)",:suite))
@@ -806,6 +812,7 @@ Method OnBeforeTestCase(suite As %String, class As %String) As %Status
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.suite, .class, .testcase)
 		Set ..CurrentTestClass = class
 		Set ..CurrentTestMethod = ""
 		if (..ListenerManager) {
@@ -829,6 +836,7 @@ Method OnAfterTestCase(suite As %String, class As %String) As %Status
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.suite, .class, .testcase)
 		If (..CoverageDetail = 2) {
 			Set tSC = ..EndCoverageTracking(suite, class)
 		}
@@ -850,6 +858,7 @@ Method OnBeforeOneTest(suite As %String, class As %String, method As %String) As
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.suite, .class, .method)
 		Set ..CurrentTestMethod = method
 		if (..ListenerManager) {
 			set tObj = {"message": "Starting test method: "}
@@ -873,6 +882,7 @@ Method OnAfterOneTest(suite As %String, class As %String, method As %String) As 
 {
 	Set tSC = $$$OK
 	Try {
+		Do ##super(.suite, .class, .method)
 		If (..CoverageDetail = 3) {
 			Set tSC = ..EndCoverageTracking(suite, class, method)
 		}

--- a/internal/testing/unit_tests/UnitTest/TestCoverage/Unit/Manager.cls
+++ b/internal/testing/unit_tests/UnitTest/TestCoverage/Unit/Manager.cls
@@ -1,0 +1,17 @@
+Class UnitTest.TestCoverage.Unit.Manager Extends %UnitTest.TestCase
+{
+
+Parameter AutoUserNames As STRING = "TestA;TestB;TestC";
+
+Method TestAutoUserNames()
+{
+    // verify the 3 usernames are automatically created
+    ZNSPACE "%SYS"
+
+    Do $$$AssertTrue(##class(Security.Users).Exists("TestA"))
+    Do $$$AssertTrue(##class(Security.Users).Exists("TestB"))
+    Do $$$AssertTrue(##class(Security.Users).Exists("TestC"))
+    Do $$$AssertNotTrue(##class(Security.Users).Exists("TestD"))
+}
+
+}

--- a/internal/testing/unit_tests/UnitTest/TestCoverage/Unit/Manager.cls
+++ b/internal/testing/unit_tests/UnitTest/TestCoverage/Unit/Manager.cls
@@ -6,7 +6,8 @@ Parameter AutoUserNames As STRING = "TestA;TestB;TestC";
 Method TestAutoUserNames()
 {
     // verify the 3 usernames are automatically created
-    ZNSPACE "%SYS"
+    New $NAMESPACE
+    Set $NAMESPACE = "%SYS"
 
     Do $$$AssertTrue(##class(Security.Users).Exists("TestA"))
     Do $$$AssertTrue(##class(Security.Users).Exists("TestB"))

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="TestCoverage.ZPM"><Module>
   <Name>TestCoverage</Name>
-  <Version>4.0.5</Version>
+  <Version>4.0.6</Version>
   <Description>Run your typical ObjectScript %UnitTest tests and see which lines of your code are executed. Includes Cobertura-style reporting for use in continuous integration tools.</Description>
   <Packaging>module</Packaging>
   <Resource Name="TestCoverage.PKG" Directory="cls" />


### PR DESCRIPTION
fixes #63: This allows "new" features like AutoUserNames to work automatically.