### PR TITLE
Fix #66; also line ending issues on docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.6]
+## [4.0.7] - 2025-09-23
+
+### Fixed
+- #66: No longer errors when a `[ Language = python ]` method has a name starting with "%"
+- coverage.list files with Windows-style line endings are now parsed properly in Linux containers
+
+## [4.0.6] - 2025-08-13
 
 ### Fixed
 - #63: TestCoverage.Manager On/After methods now call superclass so improvements to %UnitTest.Manager like AutoUserNames will work properly

--- a/cls/TestCoverage/Data/CodeUnit.cls
+++ b/cls/TestCoverage/Data/CodeUnit.cls
@@ -401,6 +401,10 @@ Method UpdateSourceMap(pSourceNamespace As %String, ByRef pCache) As %Status
 				// for each method in the .py file, we'll find the line number of the corresponding method (guaranteed to be unique) in the .cls file
 				// and then map each line in the .py file to each line in the .cls file by just going 1 by 1 down the lines 
 				Set tCLSMethodNum = pCLSCodeUnit.MethodMap.GetAt(tMethod)
+				If (tCLSMethodNum = "") {
+					// %Foo() becomes _Foo() in the Python code unit.
+					Set tCLSMethodNum = pCLSCodeUnit.MethodMap.GetAt($Replace(tMethod,"_","%"))
+				}
 				Set tMethodStart = ..MethodMap.GetAt(tMethod)
 				Set tMethodEnd = ..MethodEndMap.GetAt(tMethod)
 				Set tMethodName = tMethod
@@ -571,7 +575,12 @@ Method UpdateComplexity() As %Status
 				Quit
 			}
 			If (tSubUnit.IsPythonMethod) {
-				set tSubUnit.Complexity = tMethodComplexities."__getitem__"(tSubUnit.Name)
+				for name = tSubUnit.Name,$Replace(tSubUnit.Name,"%","_") {
+					if tMethodComplexities."__contains__"(name) {
+						set tSubUnit.Complexity = tMethodComplexities."__getitem__"(name)
+						quit
+					}
+				}
 				$$$ThrowOnError(tSubUnit.%Save(0))
 			} Else {
 				$$$ThrowOnError(tSubUnit.UpdateComplexity())

--- a/cls/TestCoverage/Manager.cls
+++ b/cls/TestCoverage/Manager.cls
@@ -425,13 +425,14 @@ ClassMethod GetCoverageTargetsForFile(pFileName As %String, Output pTargetArray)
 	
 	Set tFileStream = ##class(%Stream.FileCharacter).%New()
 	Do tFileStream.LinkToFile(pFileName)
+	Set tFileStream.LineTerminator = $c(10)
 	While 'tFileStream.AtEnd {
 		Set tFileLines($Increment(tFileLines)) = tFileStream.ReadLine()
 	}
 	
 	For tLineIndex=1:1:$Get(tFileLines) {
 		Set tLine = tFileLines(tLineIndex)
-		Set tLine = $zstrip(tLine, "<>W")
+		Set tLine = $zstrip(tLine, "<>WC")
 		// Skip blank lines
 		If (tLine = "") {
 			Continue

--- a/internal/testing/unit_tests/UnitTest/TestCoverage/Unit/TestComplexity.cls
+++ b/internal/testing/unit_tests/UnitTest/TestCoverage/Unit/TestComplexity.cls
@@ -254,4 +254,13 @@ ClassMethod ForLoopPython() [ Language = python ]
 	return 1
 }
 
+/// Complexity: 3 (1 + for + if)
+ClassMethod %ForLoopPython() [ Language = python ]
+{
+	for i in range(5):
+		if i > 4:
+			continue
+	return 1
+}
+
 }

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="TestCoverage.ZPM"><Module>
   <Name>TestCoverage</Name>
-  <Version>4.0.6</Version>
+  <Version>4.0.7</Version>
   <Description>Run your typical ObjectScript %UnitTest tests and see which lines of your code are executed. Includes Cobertura-style reporting for use in continuous integration tools.</Description>
   <Packaging>module</Packaging>
   <Resource Name="TestCoverage.PKG" Directory="cls" />


### PR DESCRIPTION
- #66: Fixed errors when a Language = python method has a name starting with "%"
- coverage.list files with Windows-style line endings are now parsed properly in Linux containers